### PR TITLE
Fix curl verbose output at pusher side.

### DIFF
--- a/post-receive
+++ b/post-receive
@@ -41,6 +41,6 @@ fi
 
 payload="{\"text\": \"$text\", \"user\": \"$USER\", \"branch\": \"$BRANCH\", \"repo\": \"$REPO\", \"count\": \"$COUNT\" ,\"event\": \"$GIT_EVENT\" ,\"tag_or_branch\": \"$TAG_OR_BRANCH\"}"
 
-curl -X "POST" "$HOOKS" \
+curl -fsSL -X "POST" "$HOOKS" \
   -H "Content-Type: application/json" \
-  -d "$payload" >> /dev/null
+  -d "$payload"


### PR DESCRIPTION
你好，这个PR改正了原来在git push时，用户控制台里会看见的curlprocess消息。
-fsSL 参数组合是常用的用于脚本的静默输出用的。
参数详见curl manpage。
